### PR TITLE
feat(#18): add setting to toggle appending of default suffix to output file name

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,3 +6,4 @@ export const NEW_LINE_CHAR = "\n";
 export const DOUBLE_NEW_LINE_CHAR = "\n\n";
 export const SECTION_CHAR = "#";
 export const MARKDOWN_FILE_EXTENSION = "md";
+export const DEFAULT_OUTPUT_FILE_NAME_SEPARATOR = "-";

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import {
 	NEW_LINE_CHAR,
 	PLUGIN_NAME,
 	SECTION_CHAR,
+	DEFAULT_OUTPUT_FILE_NAME_SEPARATOR,
 } from "./constants";
 import { AdvancedMergeTranslation } from "./translation";
 
@@ -79,9 +80,14 @@ export default class AdvancedMerge extends Plugin {
 			documentEntries.filter((entry) => this.filterNotes(folder, entry)),
 		);
 
-		const outputFileName = `${folder.path}-${
-			this.translation.get().MergedFilesuffix
-		}.md`;
+		// Append default suffix to output file name if the setting is enabled
+		let suffix = `.${MARKDOWN_FILE_EXTENSION}`;
+		if (this.settings.appendSuffixToOutputFileName) {
+			suffix = `${DEFAULT_OUTPUT_FILE_NAME_SEPARATOR}${this.translation.get().DefaultOutputFileNameSuffix}${suffix}`;
+		}
+
+		const outputFileName = `${folder.path}${suffix}`;
+
 		const fileExists = await vault.adapter.exists(outputFileName, false);
 		if (fileExists) {
 			new AdvancedMergeOverwriteFileModal(
@@ -174,7 +180,7 @@ export default class AdvancedMerge extends Plugin {
 	 * Applies filtering to input file.
 	 * @param {TFolder} folder - Selected folder.
 	 * @param {TFile} file - Files, to be included.
-	 * @returns {boolean} Provided file passses folder check.
+	 * @returns {boolean} Provided file passes folder check.
 	 */
 	private filterNotes(folder: TFolder, file: TAbstractFile): boolean {
 		return this.settings.includeNestedFolders
@@ -310,10 +316,6 @@ class AdvancedMergeSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.removeYamlProperties)
 					.onChange(async (value) => {
 						this.plugin.settings.removeYamlProperties = value;
-						this.plugin.settings.removeYamlProperties =
-							value === false
-								? value
-								: this.plugin.settings.removeYamlProperties;
 						await this.plugin.saveSettings();
 					}),
 			);
@@ -330,15 +332,31 @@ class AdvancedMergeSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.includeFilenames)
 					.onChange(async (value) => {
 						this.plugin.settings.includeFilenames = value;
-						this.plugin.settings.includeFilenames =
-							value === false
-								? value
-								: this.plugin.settings.includeFilenames;
 						await this.plugin.saveSettings();
 					}),
 			);
 
 		this.showIncludeFolderAsSectionSetting(containerEl);
+
+		// Add "append suffix to output file name" toggle in settings
+		new Setting(containerEl)
+			.setName(
+				this.plugin.translation.get()
+					.SettingAppendSuffixToOutputFileName,
+			)
+			.setDesc(
+				this.plugin.translation.get()
+					.SettingAppendSuffixToOutputFileNameDescription,
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.appendSuffixToOutputFileName)
+					.onChange(async (value) => {
+						this.plugin.settings.appendSuffixToOutputFileName =
+							value;
+						await this.plugin.saveSettings();
+					}),
+			);
 	}
 
 	private showIncludeFolderAsSectionSetting(containerEl: HTMLElement): void {
@@ -368,7 +386,7 @@ class AdvancedMergeSettingTab extends PluginSettingTab {
 }
 
 class AdvancedMergeOverwriteFileModal extends Modal {
-	private tranlation: AdvancedMergeTranslation;
+	private translation: AdvancedMergeTranslation;
 	private existingFileName: string;
 	private onSubmitHandler: (result: boolean) => void;
 
@@ -387,7 +405,7 @@ class AdvancedMergeOverwriteFileModal extends Modal {
 		handler: (result: boolean) => void,
 	) {
 		super(app);
-		this.tranlation = translation;
+		this.translation = translation;
 		this.existingFileName = existingFileName;
 		this.onSubmitHandler = handler;
 	}
@@ -399,7 +417,7 @@ class AdvancedMergeOverwriteFileModal extends Modal {
 		const { contentEl } = this;
 
 		contentEl.createEl("h3", {
-			text: `${this.tranlation.get().OverwriteFileQuestion} "${
+			text: `${this.translation.get().OverwriteFileQuestion} "${
 				this.existingFileName
 			}"?`,
 		});
@@ -407,7 +425,7 @@ class AdvancedMergeOverwriteFileModal extends Modal {
 		new Setting(contentEl)
 			.addButton((btn) =>
 				btn
-					.setButtonText(this.tranlation.get().No)
+					.setButtonText(this.translation.get().No)
 					.setCta()
 					.onClick(() => {
 						this.close();
@@ -416,7 +434,7 @@ class AdvancedMergeOverwriteFileModal extends Modal {
 			)
 			.addButton((btn) =>
 				btn
-					.setButtonText(this.tranlation.get().Yes)
+					.setButtonText(this.translation.get().Yes)
 					.setCta()
 					.onClick(() => {
 						this.close();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,6 +8,7 @@ export interface AdvancedMergePluginSettings {
 	includeFoldersAsSections: boolean;
 	removeYamlProperties: boolean;
 	includeFilenames: boolean;
+	appendSuffixToOutputFileName: boolean;
 }
 
 export const DEFAULT_SETTINGS: AdvancedMergePluginSettings = {
@@ -16,4 +17,5 @@ export const DEFAULT_SETTINGS: AdvancedMergePluginSettings = {
 	includeFoldersAsSections: false,
 	removeYamlProperties: false,
 	includeFilenames: true,
+	appendSuffixToOutputFileName: true,
 };

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -2,7 +2,7 @@ import { DEFAULT_LANGUAGE } from "./constants";
 
 export interface Translation {
 	MergeFolder: string;
-	MergedFilesuffix: string;
+	DefaultOutputFileNameSuffix: string;
 	OverwriteFileQuestion: string;
 	Settings: string;
 	SettingSortMode: string;
@@ -18,6 +18,8 @@ export interface Translation {
 	SettingRemoveYamlPropertiesDescription: string;
 	SettingIncludeFilenames: string;
 	SettingIncludeFilenamesDescription: string;
+	SettingAppendSuffixToOutputFileName: string;
+	SettingAppendSuffixToOutputFileNameDescription: string;
 	Yes: string;
 	No: string;
 }
@@ -25,7 +27,7 @@ export interface Translation {
 export const TRANSLATIONS: Record<string, Translation> = {
 	de: {
 		MergeFolder: "Ordner zusammenführen",
-		MergedFilesuffix: "zusammengeführt",
+		DefaultOutputFileNameSuffix: "zusammengeführt",
 		OverwriteFileQuestion: "Vorhandene Datei überschreiben",
 		Settings: "Einstellungen",
 		SettingIncludeNestedFolders: "Verschachtelte Ordner einbeziehen",
@@ -48,10 +50,14 @@ export const TRANSLATIONS: Record<string, Translation> = {
 		SettingIncludeFilenames: "Dateinamen einbeziehen",
 		SettingIncludeFilenamesDescription:
 			"Wenn aktiviert, werden die Dateinamen in die Ausgabedatei aufgenommen.",
+		SettingAppendSuffixToOutputFileName:
+			"Suffix zum Ausgabedateinamen hinzufügen",
+		SettingAppendSuffixToOutputFileNameDescription:
+			"Wenn aktiviert, wird das Suffix '-zusammengeführt' zum Ausgabedateinamen hinzugefügt.",
 	},
 	en: {
 		MergeFolder: "Merge folder",
-		MergedFilesuffix: "merged",
+		DefaultOutputFileNameSuffix: "merged",
 		OverwriteFileQuestion: "Overwrite existing file",
 		Settings: "Settings",
 		SettingIncludeNestedFolders: "Include nested folders",
@@ -74,10 +80,14 @@ export const TRANSLATIONS: Record<string, Translation> = {
 		SettingIncludeFilenames: "Include filenames",
 		SettingIncludeFilenamesDescription:
 			"If enabled, filenames will be included in the output file.",
+		SettingAppendSuffixToOutputFileName:
+			"Append suffix to output file name",
+		SettingAppendSuffixToOutputFileNameDescription:
+			"If enabled, the suffix '-merged' will be appended to the output file name.",
 	},
 	fi: {
 		MergeFolder: "Yhdistä kansio",
-		MergedFilesuffix: "yhdistetty",
+		DefaultOutputFileNameSuffix: "yhdistetty",
 		OverwriteFileQuestion: "Korvaa olemassa oleva tiedosto",
 		Settings: "Asetukset",
 		SettingIncludeNestedFolders: "Sisällytä sisäkkäiset kansiot",
@@ -100,10 +110,14 @@ export const TRANSLATIONS: Record<string, Translation> = {
 		SettingIncludeFilenames: "Sisällytä tiedostonimet",
 		SettingIncludeFilenamesDescription:
 			"Jos käytössä, tiedostonimet sisällytetään tulostiedostoon.",
+		SettingAppendSuffixToOutputFileName:
+			"Lisää suffixi tulostiedostonimen perään",
+		SettingAppendSuffixToOutputFileNameDescription:
+			"Jos käytössä, suffixi '-yhdistetty' lisätään tulostiedostonimen perään.",
 	},
 	fr: {
 		MergeFolder: "Fusionner le dossier",
-		MergedFilesuffix: "fusionné",
+		DefaultOutputFileNameSuffix: "fusionné",
 		OverwriteFileQuestion: "Remplacer le fichier existant",
 		Settings: "Paramètres",
 		SettingIncludeNestedFolders: "Inclure les dossiers imbriqués",
@@ -127,10 +141,14 @@ export const TRANSLATIONS: Record<string, Translation> = {
 		SettingIncludeFilenames: "Inclure les noms de fichiers",
 		SettingIncludeFilenamesDescription:
 			"Si activé, les noms de fichiers seront inclus dans le fichier de sortie.",
+		SettingAppendSuffixToOutputFileName:
+			"Ajouter un suffixe au nom du fichier de sortie",
+		SettingAppendSuffixToOutputFileNameDescription:
+			"Si activé, le suffixe '-fusionné' sera ajouté au nom du fichier de sortie.",
 	},
 	ru: {
 		MergeFolder: "Объединить папку",
-		MergedFilesuffix: "совмещенный",
+		DefaultOutputFileNameSuffix: "совмещенный",
 		OverwriteFileQuestion: "Перезаписать существующий файл",
 		Settings: "Настройки",
 		SettingIncludeNestedFolders: "Влючать вложенные папки",
@@ -153,10 +171,14 @@ export const TRANSLATIONS: Record<string, Translation> = {
 		SettingIncludeFilenames: "Включать имена файлов",
 		SettingIncludeFilenamesDescription:
 			"Если включено, имена файлов будут включены в выходной файл.",
+		SettingAppendSuffixToOutputFileName:
+			"Добавить суффикс к имени выходного файла",
+		SettingAppendSuffixToOutputFileNameDescription:
+			"Если включено, суффикс '-совмещенный' будет добавлен к имени выходного файла.",
 	},
 	ua: {
 		MergeFolder: "Об'єднати папку",
-		MergedFilesuffix: "об'єднані",
+		DefaultOutputFileNameSuffix: "об'єднані",
 		OverwriteFileQuestion: "Перезаписати існуючий файл",
 		Settings: "Налаштування",
 		SettingIncludeNestedFolders: "Включити вкладені папки",
@@ -179,6 +201,10 @@ export const TRANSLATIONS: Record<string, Translation> = {
 		SettingIncludeFilenames: "Включити імена файлів",
 		SettingIncludeFilenamesDescription:
 			"Якщо ввімкнено, імена файлів будуть включені у вихідний файл.",
+		SettingAppendSuffixToOutputFileName:
+			"Додати суффікс до імені вихідного файлу",
+		SettingAppendSuffixToOutputFileNameDescription:
+			"Якщо ввімкнено, суффікс '-об'єднані' буде додано до імені вихідного файлу.",
 	},
 };
 


### PR DESCRIPTION
## Feature
Add a new setting to allow users to toggle the appending of the default suffix `-merged` to the final output file name. For more information, reference discussion #18.

## Minor Fixes
- Fixed some typos
- Removed redundant value checks from two existing settings

## Demo 
![Screen Recording 2026-03-10 at 6 06 46 PM](https://github.com/user-attachments/assets/1157c43d-e745-42f1-ab4f-cc3b28ce9402)

## Open Tasks
- [ ] Review the AI generated translations for the new setting title and description are correct.